### PR TITLE
FE/0806/사전설문_추가질문 완료 버튼

### DIFF
--- a/front/src/Components/Common/Button/Button.jsx
+++ b/front/src/Components/Common/Button/Button.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { styled, css } from "styled-components";
 
-const Button = ({ text, style, onClick }) => {
+const Button = ({ text, style, onClick, ...rest }) => {
   return (
-    <CommonButton $style={style} onClick={onClick}>
+    <CommonButton $style={style} onClick={onClick} {...rest}>
       {text}
     </CommonButton>
   );

--- a/front/src/Pages/SurveyPage/ExtraSurvey/index.jsx
+++ b/front/src/Pages/SurveyPage/ExtraSurvey/index.jsx
@@ -107,7 +107,7 @@ const ExtraSurvey = ({ buttonHandler }) => {
       [group]: newValue,
     }));
   };
-  const checkBtnActivity = () => {
+  const updateButtonStatusIfAllAnswered = () => {
     if (
       surveyData["drivingRecord"] !== null &&
       surveyData["familySize"] !== null &&
@@ -119,7 +119,7 @@ const ExtraSurvey = ({ buttonHandler }) => {
   };
   useEffect(() => {
     if (!isBtnActive) {
-      checkBtnActivity();
+      updateButtonStatusIfAllAnswered();
     }
   }, [surveyData]);
 

--- a/front/src/Pages/SurveyPage/ExtraSurvey/index.jsx
+++ b/front/src/Pages/SurveyPage/ExtraSurvey/index.jsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import * as S from "../styles";
 import SurveyHeader from "../../../Components/Survey/SurveyHeader";
 import SurveyOptionGroup from "../../../Components/Survey/SurveyOptionGroup";
 import Button from "../../../Components/Common/Button/Button";
-import { css, styled } from "styled-components";
 import BudgetSliderGroup from "./BudgetSliderGroup";
+import { css } from "styled-components";
 
 const extraSurveyInfo = [
   {
@@ -92,13 +92,14 @@ const extraSurveyInfo = [
     ],
   },
 ];
-const ExtraSurvey = () => {
+const ExtraSurvey = ({ buttonHandler }) => {
   const [surveyData, setSurveyData] = useState({
     drivingRecord: 0,
     familySize: 0,
     purpose: null,
     viewpoint: null,
   });
+  const [isBtnActive, setIsBtnActive] = useState(false);
 
   const handleOptionChange = (group, newValue) => {
     setSurveyData((prevData) => ({
@@ -106,6 +107,21 @@ const ExtraSurvey = () => {
       [group]: newValue,
     }));
   };
+  const checkBtnActivity = () => {
+    if (
+      surveyData["drivingRecord"] !== null &&
+      surveyData["familySize"] !== null &&
+      surveyData["purpose"] !== null &&
+      surveyData["viewpoint"] !== null
+    ) {
+      setIsBtnActive(true);
+    }
+  };
+  useEffect(() => {
+    if (!isBtnActive) {
+      checkBtnActivity();
+    }
+  }, [surveyData]);
 
   return (
     <S.SurveyContent>
@@ -124,8 +140,37 @@ const ExtraSurvey = () => {
       ))}
 
       <BudgetSliderGroup />
+      <Button
+        text="완료"
+        $isActive={isBtnActive}
+        style={SurveyBtnStyle}
+        onClick={buttonHandler}
+      />
     </S.SurveyContent>
   );
 };
+
+const SurveyBtnStyle = css`
+  width: 608px;
+  height: 52px;
+
+  position: relative;
+
+  color: ${({ theme }) => theme.color.grey1000};
+  background-color: ${({ theme }) => theme.color.primary_default};
+
+  border-radius: 6px;
+  border: 1px solid ${({ theme }) => theme.color.primary_default};
+  ${({ theme }) => theme.font.Body3_Medium};
+
+  margin: 52px 0px 36px;
+
+  ${({ $isActive }) =>
+    !$isActive &&
+    css`
+      opacity: 0.3;
+      pointer-events: none;
+    `}
+`;
 
 export default ExtraSurvey;

--- a/front/src/Pages/SurveyPage/index.jsx
+++ b/front/src/Pages/SurveyPage/index.jsx
@@ -4,13 +4,15 @@ import AgeSurvey from "./AgeSurvey";
 import LifestyleSurvey from "./LifestyleSurvey";
 import ExtraSurvey from "./ExtraSurvey";
 import ProgressBar from "../../Components/Survey/ProgressBar";
+import { useNavigate } from "react-router-dom";
 
 const SurveyPage = () => {
+  const navigate = useNavigate();
   const [page, setPage] = useState(0);
   const Pages = {
     0: <AgeSurvey buttonHandler={() => setPage(1)} />,
     1: <LifestyleSurvey linkHandler={() => setPage(2)} />,
-    2: <ExtraSurvey />,
+    2: <ExtraSurvey buttonHandler={() => navigate("/etc_end")} />,
   };
   return (
     <Wrapper>


### PR DESCRIPTION
## 스크린샷
https://github.com/softeerbootcamp-2nd/A1-PoongCha/assets/63971484/1ce4921f-f1be-4082-9bf1-5345396a26e2

## 작업 내용
- buttonHandler : navigate("/etc_end")
- 4개 선택지 모두 활성화됐을 때 완료 버튼 활성화
   - surveyData (유저가 선택한 선택지 정보)가 변했을 때 버튼이 active 상태가 아니라면 > surveyData에 null 있는지 확인하고 버튼 상태 업데이트 (useEffect 사용)
   - Button 컴포넌트 수정 : Button 컴포넌트에 추가 prop (isBtnActive) 내려줌
   - isBtnActive = false 일땐 opacity:0.3 줌


## 주의사항

Closes #{33}
