### PR TITLE
Fe/0808/59 트림선택 헤더 버튼

### DIFF
--- a/front/src/Components/Header/OptionalHeader/Navigation/index.jsx
+++ b/front/src/Components/Header/OptionalHeader/Navigation/index.jsx
@@ -1,27 +1,45 @@
 import React from "react";
 import { css, styled } from "styled-components";
-import Button from "../../Common/Button/Button";
+import { useLocation } from "react-router";
+import Button from "../../../Common/Button/Button";
+import useButtonNavigation from "../../../../hooks/useButtonNavigation";
+
+const navItems = [
+  { title: "1 트림", detail: "Le Blanc(르블랑)", path: "/custom/trim" },
+  {
+    title: "2 색상",
+    detail: "어비스 블랙펄 / 퀄팅 천연(블랙)",
+    path: "/custom/color",
+  },
+  {
+    title: "3 옵션",
+    detail: "컴포트2, 현대 스마트 센스 1, 주차보조",
+    path: "/custom/options",
+  },
+];
 
 const Navigation = () => {
+  const { pathname } = useLocation();
+
+  const move = useButtonNavigation();
+
   return (
     <Wrapper>
       <NavContainer>
-        <Nav>
-          <NavTitle>1 트림</NavTitle>
-          <NavDetail>Le Blanc(르블랑)</NavDetail>
-        </Nav>
-        <Nav>
-          <NavTitle>2 색상</NavTitle>
-          <NavDetail>어비스 블랙펄 / 퀄팅 천연(블랙)</NavDetail>
-        </Nav>
-        <Nav>
-          <NavTitle>3 옵션</NavTitle>
-          <NavDetail>컴포트2, 현대 스마트 센스 1, 주차보조</NavDetail>
-        </Nav>
+        {navItems.map((item, index) => (
+          <Nav key={index}>
+            <NavTitle $active={item.path === pathname}>{item.title}</NavTitle>
+            <NavDetail>{item.detail}</NavDetail>
+          </Nav>
+        ))}
       </NavContainer>
       <BtnsContainer>
         <Button text="요금 상세" style={amoutDetailBtnStyle} />
-        <Button text="견적내기" style={estimateBtnStyle} />
+        <Button
+          text="견적내기"
+          style={estimateBtnStyle}
+          onClick={() => move("/result")}
+        />
       </BtnsContainer>
     </Wrapper>
   );
@@ -59,7 +77,8 @@ const NavDetail = styled.div`
 
 const NavTitle = styled.div`
   ${({ theme }) => theme.font.Body4_Medium};
-  color: ${({ theme }) => theme.color.primary_default};
+  color: ${({ $active, theme }) =>
+    $active ? theme.color.primary_default : theme.color.grey600};
 `;
 
 const Nav = styled.div`

--- a/front/src/Components/Header/OptionalHeader/index.jsx
+++ b/front/src/Components/Header/OptionalHeader/index.jsx
@@ -1,15 +1,14 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useLocation } from "react-router-dom";
 import Navigation from "./Navigation";
 
 const OptionalHeader = () => {
   const { pathname } = useLocation();
 
-  if (pathname === "/") {
-    return null;
-  } else if (pathname === "/custom") {
-    return <Navigation />;
-  }
+  const customPaths = ["/custom/trim", "/custom/color"];
+
+  if (pathname === "/") return null;
+  if (customPaths.includes(pathname)) return <Navigation />;
 };
 
 export default OptionalHeader;

--- a/front/src/Pages/LandingPage/index.jsx
+++ b/front/src/Pages/LandingPage/index.jsx
@@ -19,7 +19,7 @@ const LandingPage = () => {
         <Button
           text="직접 만들래요"
           style={Direct}
-          onClick={() => move("/custom")}
+          onClick={() => move("/custom/trim")}
         />
         <Button
           text="추천받기"


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `{이슈 번호} feat : PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?

## 작업 내용
- 네비게이션 내부 버튼 2개 (요금상세, 견적내기 버튼 개발)
- 네비게이션 내부 트림 색상 옵션 페이지로 이동시 해당 페이지 색상 표시
- 랜딩페이지 직접만들래요 주소 변경 move(/custom)으로 되어 있었슴

## 스크린샷
<img width="1578" alt="스크린샷 2023-08-08 오후 11 45 56" src="https://github.com/softeerbootcamp-2nd/A1-PoongCha/assets/64758823/ec48f9c1-6dcf-4d14-ad17-5dad8b937fa5">

Closes #59 
