### PR TITLE
FE/0809/트림 선택 페이지 레이아웃 수정

### DIFF
--- a/front/src/Components/Custom/TrimOptionGroup/index.jsx
+++ b/front/src/Components/Custom/TrimOptionGroup/index.jsx
@@ -11,7 +11,7 @@ const TrimOptionGroup = ({ options, selectedOption, handleOptionSelect }) => {
     <Wrapper>
       {isTooltipOpen && <Tooltip offset={810} />}
       <Title onMouseEnter={openTooltip} onMouseLeave={closeTooltip}>
-        <span class="trimOptionTitle">트림</span>
+        <span>트림</span>
         <Button text="비교하기" style={TrimComparisonBtnStyle} />
       </Title>
       {options.map((option, index) => (

--- a/front/src/Pages/CustomPage/TrimPage/TrimCustomSideBar/index.jsx
+++ b/front/src/Pages/CustomPage/TrimPage/TrimCustomSideBar/index.jsx
@@ -152,11 +152,8 @@ const LinkBtnStyle = css`
 `;
 
 const CustomBarContent = styled.div`
-  width: 473px; // 피그마 기준
-  /* width: 100%; */
-
-  padding-left: 36px;
-  padding-right: 128px;
+  width: 309px;
+  margin-right: 128px;
 
   box-sizing: border-box;
 `;
@@ -164,7 +161,8 @@ const CustomBarContent = styled.div`
 const Wrapper = styled.div`
   display: flex;
   justify-content: flex-end;
-  width: 29%;
+  flex: 0 0 auto;
+  width: 473px;
   height: 1292px;
 `;
 export default TrimCustomSideBar;

--- a/front/src/Pages/CustomPage/TrimPage/index.jsx
+++ b/front/src/Pages/CustomPage/TrimPage/index.jsx
@@ -12,9 +12,10 @@ const TrimPage = () => {
 };
 
 const Component1 = styled.div`
+  flex: 0 0 auto;
+  width: calc(100% - 473px);
   position: fixed;
 
-  width: 71%;
   height: 100%;
 
   left: 0;


### PR DESCRIPTION
## 작업 내용
### 📌 트림 선택 페이지 레이아웃 변경
   - 트림 선택 영역(우측) 너비 고정 : 전체 473px, 콘텐츠 영역 309px (기획서 기준)
   - 왼쪽 영역은 브라우저 사이즈에 따라 변함 `width: calc(100% - 473px);`

## 스크린샷

https://github.com/softeerbootcamp-2nd/A1-PoongCha/assets/63971484/a97132d7-baa6-40ee-b106-971057a10f22


## 주의사항

Closes #{이슈 번호}
